### PR TITLE
Patch URLs to GitHub

### DIFF
--- a/docs/workshops/archi-beginner/6-merge-change.md
+++ b/docs/workshops/archi-beginner/6-merge-change.md
@@ -6,7 +6,7 @@ title: "Merge change"
 
 On regular intervals all committed and published branches need to be merged into the main branch which will trickle down into all subsequent branches.
 
-1. Log onto your GitHub Account at [GitHub.com](github.com) 
+1. Log onto your GitHub Account at [GitHub.com](https://github.com) 
 2. In <https://github.com/NBility-Model>, create a Github pull request from your topic branch on by clicking on the button [**Compare & Pull Request**].
 
 ![coArchi-create-pull-request](/images/Create%20Pull%20request.PNG)

--- a/docs/workshops/preparation/2-prepare-github.md
+++ b/docs/workshops/preparation/2-prepare-github.md
@@ -1,6 +1,6 @@
 # Preparing your GitHub account to configure Archi integration
 
-1. Log onto your GitHub Account at [GitHub.com](github.com) or create a GitHub account at [GitHub.com](github.com)
+1. Log onto your GitHub Account at [GitHub.com](https://github.com) or create a GitHub account at [GitHub.com](https://github.com)
 2. Please share your GitHub account name by emailing it to OSPO@alliander.com, so that we can add you to the NBility-Model GitHub organization.
 3. Accept the invitation to join the NBility-Model GitHub organization. Note that this process may take some time as it requires manual intervention by the NBility-Model maintainers. In the meantime, you can proceed with step 4.
 4. To configure Archi for Github integration you would need to create a Personal Access Token (PAT) from your user account.  For a detailed overview of the process you can visit https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-toke


### PR DESCRIPTION
URLs to GitHub.com missed the `https://` prefix, causing them to break. Fixed